### PR TITLE
build: build ui-components before publishing

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -32,6 +32,7 @@ jobs:
           cache-dependency-path: yarn.lock
 
       - run: yarn install --frozen-lockfile
+      - run: yarn build
 
       # Adapted from https://johnny.sh/notes/publish-canary-lerna-cicd/
       - name: configure NPM token


### PR DESCRIPTION
I get an error when using the latest:
```
[commonjs--resolver] Failed to resolve entry for package "@agoric/ui-components". The package may have incorrect main/module/exports specified in its package.json.
error during build:
Error: Failed to resolve entry for package "@agoric/ui-components". The package may have incorrect main/module/exports specified in its package.json.
```
I think because the package was missing its `dist` folder, because it isn't being built before being published. @turadg I may need help testing this