### PR TITLE
fix: resolve wallet connection for empty wallet data

### DIFF
--- a/packages/web-components/src/wallet-connection/watchWallet.js
+++ b/packages/web-components/src/wallet-connection/watchWallet.js
@@ -52,10 +52,10 @@ export const watchWallet = async (chainStorageWatcher, address) => {
       chainStorageWatcher.watchLatest(
         ['data', `published.wallet.${address}.current`],
         value => {
+          res();
           const { offerToPublicSubscriberPaths: currentPaths } = value;
           if (currentPaths === lastPaths) return;
 
-          res();
           publicSubscriberPathsNotifierKit.updater.updateState(
             harden(currentPaths),
           );


### PR DESCRIPTION
refs https://github.com/Agoric/dapp-inter/issues/151

`res()` was never being called because the data was empty, and the callback was returning early. So, the wallet connection was hanging forever.

The empty wallet data state resulted from a smart wallet that was created before the vaults upgrade, but had never made an offer.

We'll need to update the dapps after this new version is published.