### PR TITLE
smart-wallet provisioning from web-components

### DIFF
--- a/packages/web-components/src/wallet-connection/makeInteractiveSigner.js
+++ b/packages/web-components/src/wallet-connection/makeInteractiveSigner.js
@@ -184,7 +184,7 @@ export const makeInteractiveSigner = async (
      *         RPC connection fails, RPC service fails to broadcast (
      *         for example, if signature verification fails)
      */
-    submitProvision: async () => {
+    provisionSmartWallet: async () => {
       const { accountNumber, sequence } = await signingClient.getSequence(
         address,
       );

--- a/packages/web-components/src/wallet-connection/makeInteractiveSigner.js
+++ b/packages/web-components/src/wallet-connection/makeInteractiveSigner.js
@@ -179,7 +179,6 @@ export const makeInteractiveSigner = async (
     /**
      * Sign and broadcast Provision for a new smart wallet
      *
-     * @param async
      * @throws if account does not exist on chain, user cancels,
      *         RPC connection fails, RPC service fails to broadcast (
      *         for example, if signature verification fails)

--- a/packages/web-components/src/wallet-connection/makeInteractiveSigner.js
+++ b/packages/web-components/src/wallet-connection/makeInteractiveSigner.js
@@ -7,7 +7,10 @@ import {
   createBankAminoConverters,
   createAuthzAminoConverters,
 } from '@cosmjs/stargate';
-import { MsgWalletSpendAction } from '@agoric/cosmic-proto/swingset/msgs.js';
+import {
+  MsgWalletSpendAction,
+  MsgProvision,
+} from '@agoric/cosmic-proto/swingset/msgs.js';
 import { stableCurrency, bech32Config } from './chainInfo.js';
 import { Errors } from '../errors.js';
 
@@ -25,6 +28,16 @@ const toAccAddress = address => {
   return fromBech32(address).data;
 };
 
+// XXX domain of @agoric/cosmic-proto
+/**
+ * non-exhaustive list of powerFlags
+ *
+ * See also MsgProvision in golang/cosmos/proto/agoric/swingset/msgs.proto
+ */
+const PowerFlags = {
+  SMART_WALLET: 'SMART_WALLET',
+};
+
 /**
  * `/agoric.swingset.XXX` matches package agoric.swingset in swingset/msgs.proto
  * aminoType taken from Type() in golang/cosmos/x/swingset/types/msgs.go
@@ -34,6 +47,10 @@ const SwingsetMsgs = {
     typeUrl: '/agoric.swingset.MsgWalletSpendAction',
     aminoType: 'swingset/WalletSpendAction',
   },
+  MsgProvision: {
+    typeUrl: '/agoric.swingset.MsgProvision',
+    aminoType: 'swingset/Provision',
+  },
 };
 
 /** @typedef {{owner: string, spendAction: string}} WalletSpendAction */
@@ -42,6 +59,7 @@ const SwingsetRegistry = new Registry([
   ...defaultRegistryTypes,
   // XXX should this list be "upstreamed" to @agoric/cosmic-proto?
   [SwingsetMsgs.MsgWalletSpendAction.typeUrl, MsgWalletSpendAction],
+  [SwingsetMsgs.MsgProvision.typeUrl, MsgProvision],
 ]);
 
 /**
@@ -54,6 +72,11 @@ const zeroFee = () => {
     gas: '300000', // TODO: estimate gas?
   };
   return fee;
+};
+
+const dbg = label => x => {
+  console.log(label, x);
+  return x;
 };
 
 /**
@@ -70,6 +93,37 @@ const SwingsetConverters = {
       spendAction,
       owner: toBase64(toAccAddress(owner)),
     }),
+  },
+  [SwingsetMsgs.MsgProvision.typeUrl]: {
+    aminoType: SwingsetMsgs.MsgProvision.aminoType,
+    toAmino: protoVal => {
+      const { nickname, address, powerFlags, submitter } = dbg(
+        'provision toAmino protoVal',
+      )(protoVal);
+      return {
+        address: toBech32(
+          bech32Config.bech32PrefixAccAddr,
+          fromBase64(address),
+        ),
+        nickname,
+        powerFlags,
+        submitter: toBech32(
+          bech32Config.bech32PrefixAccAddr,
+          fromBase64(submitter),
+        ),
+      };
+    },
+    fromAmino: aminoVal => {
+      const { nickname, address, powerFlags, submitter } = dbg(
+        'provision fromAmino aminoVal',
+      )(aminoVal);
+      return {
+        address: toBase64(toAccAddress(address)),
+        nickname,
+        powerFlags,
+        submitter: toBase64(toAccAddress(submitter)),
+      };
+    },
   },
 };
 
@@ -121,6 +175,43 @@ export const makeInteractiveSigner = async (
   return harden({
     address, // TODO: address can change
     isNanoLedger: key.isNanoLedger,
+
+    /**
+     * Sign and broadcast Provision for a new smart wallet
+     *
+     * @param async
+     * @throws if account does not exist on chain, user cancels,
+     *         RPC connection fails, RPC service fails to broadcast (
+     *         for example, if signature verification fails)
+     */
+    submitProvision: async () => {
+      const { accountNumber, sequence } = await signingClient.getSequence(
+        address,
+      );
+      console.log({ accountNumber, sequence });
+
+      const b64address = toBase64(toAccAddress(address));
+
+      const act1 = {
+        typeUrl: SwingsetMsgs.MsgProvision.typeUrl,
+        value: {
+          address: b64address,
+          nickname: 'my wallet',
+          powerFlags: [PowerFlags.SMART_WALLET],
+          submitter: b64address,
+        },
+      };
+
+      const msgs = [act1];
+      console.log('sign provision', { address, msgs, fee });
+
+      const tx = await signingClient.signAndBroadcast(address, msgs, fee);
+      console.log('spend action result tx', tx);
+      assertIsDeliverTxSuccess(tx);
+
+      return tx;
+    },
+
     /**
      * Sign and broadcast WalletSpendAction
      *

--- a/packages/web-components/src/wallet-connection/walletConnection.js
+++ b/packages/web-components/src/wallet-connection/walletConnection.js
@@ -13,7 +13,7 @@ export const makeAgoricWalletConnection = async chainStorageWatcher => {
   // @ts-expect-error cast (checked above)
   const keplr = window.keplr;
 
-  const { address, submitSpendAction, submitProvision } =
+  const { address, submitSpendAction, provisionSmartWallet } =
     await makeInteractiveSigner(
       chainStorageWatcher.chainId,
       chainStorageWatcher.rpcAddr,
@@ -49,6 +49,7 @@ export const makeAgoricWalletConnection = async chainStorageWatcher => {
       onStatusChange({ status: 'seated', data: { txn, offerId: id } });
     } catch (e) {
       onStatusChange({ status: 'error', data: e });
+      return;
     }
 
     const iterator = subscribeLatest(walletNotifiers.walletUpdatesNotifier);
@@ -74,7 +75,7 @@ export const makeAgoricWalletConnection = async chainStorageWatcher => {
   return {
     makeOffer,
     address,
-    submitProvision,
+    provisionSmartWallet,
     ...walletNotifiers,
   };
 };

--- a/packages/web-components/src/wallet-connection/walletConnection.js
+++ b/packages/web-components/src/wallet-connection/walletConnection.js
@@ -13,12 +13,13 @@ export const makeAgoricWalletConnection = async chainStorageWatcher => {
   // @ts-expect-error cast (checked above)
   const keplr = window.keplr;
 
-  const { address, submitSpendAction } = await makeInteractiveSigner(
-    chainStorageWatcher.chainId,
-    chainStorageWatcher.rpcAddr,
-    keplr,
-    SigningStargateClient.connectWithSigner,
-  );
+  const { address, submitSpendAction, submitProvision } =
+    await makeInteractiveSigner(
+      chainStorageWatcher.chainId,
+      chainStorageWatcher.rpcAddr,
+      keplr,
+      SigningStargateClient.connectWithSigner,
+    );
 
   const walletNotifiers = await watchWallet(chainStorageWatcher, address);
 
@@ -48,7 +49,6 @@ export const makeAgoricWalletConnection = async chainStorageWatcher => {
       onStatusChange({ status: 'seated', data: { txn, offerId: id } });
     } catch (e) {
       onStatusChange({ status: 'error', data: e });
-      return;
     }
 
     const iterator = subscribeLatest(walletNotifiers.walletUpdatesNotifier);
@@ -74,6 +74,7 @@ export const makeAgoricWalletConnection = async chainStorageWatcher => {
   return {
     makeOffer,
     address,
+    submitProvision,
     ...walletNotifiers,
   };
 };

--- a/packages/web-components/src/wallet-connection/watchWallet.js
+++ b/packages/web-components/src/wallet-connection/watchWallet.js
@@ -65,33 +65,21 @@ export const watchWallet = async (chainStorageWatcher, address) => {
     ),
   );
 
-  // NB: this watches '.current' but only notifies of changes to offerToPublicSubscriberPaths
-  await /** @type {Promise<void>} */ (
-    new Promise((res, rej) => {
-      let lastPaths;
-      chainStorageWatcher.watchLatest(
-        ['data', `published.wallet.${address}.current`],
-        value => {
-          res();
-          const { offerToPublicSubscriberPaths: currentPaths } = value;
-          if (currentPaths === lastPaths) return;
+  let lastPaths;
+  chainStorageWatcher.watchLatest(
+    ['data', `published.wallet.${address}.current`],
+    value => {
+      const { offerToPublicSubscriberPaths: currentPaths } = value;
+      if (currentPaths === lastPaths) return;
 
-          publicSubscriberPathsNotifierKit.updater.updateState(
-            harden(currentPaths),
-          );
-        },
-        err => {
-          if (!lastPaths) {
-            rej();
-          } else {
-            throw Error(err);
-          }
-        },
+      publicSubscriberPathsNotifierKit.updater.updateState(
+        harden(currentPaths),
       );
-    })
-  ).catch(() => {
-    console.error(Errors.noSmartWallet);
-  });
+    },
+    err => {
+      throw Error(err);
+    },
+  );
 
   const watchChainBalances = () => {
     const brandToPurse = new Map();

--- a/packages/web-components/src/wallet-connection/watchWallet.js
+++ b/packages/web-components/src/wallet-connection/watchWallet.js
@@ -2,7 +2,6 @@
 import { makeNotifierKit } from '@agoric/notifier';
 import { AmountMath } from '@agoric/ertp';
 import { iterateLatest, makeFollower, makeLeader } from '@agoric/casting';
-import { Errors } from '../errors.js';
 import { queryBankBalances } from '../queryBankBalances.js';
 
 /** @typedef {import('@agoric/smart-wallet/src/types.js').Petname} Petname */

--- a/packages/web-components/src/wallet-connection/watchWallet.js
+++ b/packages/web-components/src/wallet-connection/watchWallet.js
@@ -71,7 +71,6 @@ export const watchWallet = async (chainStorageWatcher, address) => {
     ['data', `published.wallet.${address}.current`],
     value => {
       smartWalletStatusNotifierKit.provisioned = true;
-
       const { offerToPublicSubscriberPaths: currentPaths } = value;
       if (currentPaths === lastPaths) return;
 

--- a/packages/web-components/src/wallet-connection/watchWallet.js
+++ b/packages/web-components/src/wallet-connection/watchWallet.js
@@ -64,10 +64,14 @@ export const watchWallet = async (chainStorageWatcher, address) => {
     ),
   );
 
+  const smartWalletStatusNotifierKit = {};
+
   let lastPaths;
   chainStorageWatcher.watchLatest(
     ['data', `published.wallet.${address}.current`],
     value => {
+      smartWalletStatusNotifierKit.provisioned = true;
+
       const { offerToPublicSubscriberPaths: currentPaths } = value;
       if (currentPaths === lastPaths) return;
 
@@ -76,7 +80,11 @@ export const watchWallet = async (chainStorageWatcher, address) => {
       );
     },
     err => {
-      throw Error(err);
+      if (!lastPaths) {
+        smartWalletStatusNotifierKit.provisioned = false;
+      } else {
+        throw Error(err);
+      }
     },
   );
 
@@ -226,5 +234,6 @@ export const watchWallet = async (chainStorageWatcher, address) => {
     pursesNotifier: pursesNotifierKit.notifier,
     publicSubscribersNotifier: publicSubscriberPathsNotifierKit.notifier,
     walletUpdatesNotifier: walletUpdatesNotifierKit.notifier,
+    smartWalletStatusNotifierKit,
   };
 };

--- a/packages/web-components/src/wallet-connection/watchWallet.js
+++ b/packages/web-components/src/wallet-connection/watchWallet.js
@@ -90,7 +90,7 @@ export const watchWallet = async (chainStorageWatcher, address) => {
       );
     })
   ).catch(() => {
-    throw Error(Errors.noSmartWallet);
+    console.error(Errors.noSmartWallet);
   });
 
   const watchChainBalances = () => {

--- a/packages/web-components/test/walletConnection.test.js
+++ b/packages/web-components/test/walletConnection.test.js
@@ -7,6 +7,8 @@ import {
   // @ts-expect-error exported by mock below
   // eslint-disable-next-line import/named
   submitSpendAction as mockSubmitSpendAction,
+  // @ts-expect-error exported by mock below
+  // eslint-disable-next-line import/named
   provisionSmartWallet as mockProvisionSmartWallet,
 } from '../src/wallet-connection/makeInteractiveSigner.js';
 

--- a/packages/web-components/test/walletConnection.test.js
+++ b/packages/web-components/test/walletConnection.test.js
@@ -56,18 +56,15 @@ describe('makeAgoricWalletConnection', () => {
     expect(connection.address).toEqual(testAddress);
   });
 
+  // Currently ignoring this test as not throwing on no smart-wallet, just catching
   it('throws if no smart wallet found', async () => {
     const watcher = {
       chainId: 'agoric-foo',
       rpcAddr: 'https://foo.agoric.net:443',
-      watchLatest: (_path, _onUpdate, onError) => {
-        onError('not found');
-      },
+      watchLatest: (_path, _onUpdate) => {},
     };
 
-    await expect(makeAgoricWalletConnection(watcher)).rejects.toThrowError(
-      Errors.noSmartWallet,
-    );
+    await expect(makeAgoricWalletConnection(watcher));
   });
 
   it('submits a spend action', async () => {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #41 

## Description

Updates to the [interactiveSigner](https://github.com/WietzeSlagman/ui-kit/blob/main/packages/web-components/src/wallet-connection/makeInteractiveSigner.js) which includes a `submitProvision` transaction that provisions a smart wallet for the account provided to `makeAgoricWalletConnection`.

Updates to [walletConnection](https://github.com/WietzeSlagman/ui-kit/blob/main/packages/web-components/src/wallet-connection/walletConnection.js) exposing the `submitProvision` to the dev through `makeAgoricWalletConnection`

Updates to [watchWallet](https://github.com/WietzeSlagman/ui-kit/blob/main/packages/web-components/src/wallet-connection/watchWallet.js) no longer throwing on an account that doesn't have a smart-wallet attached to it. This is something to potentially update and consider changing @samsiegart 

### Security Considerations

More easily reachable cosmos messages for developers, potentially able to force pop-ups of Keplr smart-wallet provision transactions unwanted

### Scaling Considerations


### Documentation Considerations


### Testing Considerations

Updated [walletConnection.test.js](https://github.com/WietzeSlagman/ui-kit/blob/main/packages/web-components/test/walletConnection.test.js) to no longer require a throw on no smart-wallet, could use better testing methods and a rename