### PR TITLE
remove addtional error check on smart-wallet

### DIFF
--- a/packages/web-components/src/wallet-connection/watchWallet.js
+++ b/packages/web-components/src/wallet-connection/watchWallet.js
@@ -83,10 +83,8 @@ export const watchWallet = async (chainStorageWatcher, address) => {
       );
     },
     err => {
-      if (
-        !lastPaths &&
-        err === 'could not get vstorage path: unknown request'
-      ) {
+      // !lastPaths expectation is that there is no smart-wallet
+      if (!lastPaths) {
         smartWalletStatusNotifierKit.updater.updateState(
           harden({ provisioned: false }),
         );


### PR DESCRIPTION
closes: #50
refs: #42

## Description

Ensure that the chainStorageWatcher does not throw when there is no smart-wallet present.

Initial fix with additional checks in #42 no longer works, most likely due to updated wallet factory?

### Security Considerations

Assuming an error with `!lastPaths` is always going to be a smart-wallet not provisioned

### Scaling Considerations

### Documentation Considerations

### Testing Considerations

Tests still pass