### PR TITLE
Update deprecated vstorage queries

### DIFF
--- a/packages/rpc/src/batchQuery.ts
+++ b/packages/rpc/src/batchQuery.ts
@@ -24,9 +24,7 @@ export const batchVstorageQuery = async (
   const requests = urls.map(url => fetch(url));
 
   return Promise.all(requests)
-    .then(responseDatas => {
-      return Promise.all(responseDatas.map(res => res.json()));
-    })
+    .then(responseDatas => Promise.all(responseDatas.map(res => res.json())))
     .then(responses =>
       responses.map((res, index) => {
         if (paths[index][0] === AgoricChainStoragePathKind.Children) {

--- a/packages/rpc/src/chainStorageWatcher.ts
+++ b/packages/rpc/src/chainStorageWatcher.ts
@@ -12,8 +12,8 @@ type Subscriber<T> = {
 
 const defaults = {
   newPathQueryDelayMs: 20,
-  refreshLowerBoundMs: 2000,
-  refreshUpperBoundMs: 4000,
+  refreshLowerBoundMs: 4000,
+  refreshUpperBoundMs: 8000,
 };
 
 const randomRefreshPeriod = (
@@ -36,9 +36,8 @@ export type ChainStorageWatcher = ReturnType<
 >;
 
 /**
- * Periodically queries the most recent data from chain storage, batching RPC
- * requests for efficiency.
- * @param rpcAddr RPC server URL
+ * Periodically queries the most recent data from chain storage.
+ * @param apiAddr API server URL
  * @param chainId the chain id to use
  * @param onError
  * @param marshaller CapData marshal to use
@@ -48,7 +47,7 @@ export type ChainStorageWatcher = ReturnType<
  * @returns
  */
 export const makeAgoricChainStorageWatcher = (
-  rpcAddr: string,
+  apiAddr: string,
   chainId: string,
   onError?: (e: Error) => void,
   marshaller = makeClientMarshaller(),
@@ -105,11 +104,12 @@ export const makeAgoricChainStorageWatcher = (
     }
 
     try {
-      const data = await batchVstorageQuery(
-        rpcAddr,
+      const responses = await batchVstorageQuery(
+        apiAddr,
         marshaller.fromCapData,
         paths,
       );
+      const data = Object.fromEntries(responses);
       watchedPathsToSubscribers.forEach((subscribers, path) => {
         // Path was watched after query fired, wait until next round.
         if (!data[path]) return;
@@ -229,7 +229,7 @@ export const makeAgoricChainStorageWatcher = (
   return {
     watchLatest,
     chainId,
-    rpcAddr,
+    apiAddr,
     marshaller,
     queryOnce,
     queryBoardAux,

--- a/packages/web-components/src/wallet-connection/walletConnection.js
+++ b/packages/web-components/src/wallet-connection/walletConnection.js
@@ -5,7 +5,7 @@ import { makeInteractiveSigner } from './makeInteractiveSigner.js';
 import { watchWallet } from './watchWallet.js';
 import { Errors } from '../errors.js';
 
-export const makeAgoricWalletConnection = async chainStorageWatcher => {
+export const makeAgoricWalletConnection = async (chainStorageWatcher, rpc) => {
   if (!('keplr' in window)) {
     throw Error(Errors.noKeplr);
   }
@@ -16,12 +16,12 @@ export const makeAgoricWalletConnection = async chainStorageWatcher => {
   const { address, submitSpendAction, provisionSmartWallet } =
     await makeInteractiveSigner(
       chainStorageWatcher.chainId,
-      chainStorageWatcher.rpcAddr,
+      rpc,
       keplr,
       SigningStargateClient.connectWithSigner,
     );
 
-  const walletNotifiers = await watchWallet(chainStorageWatcher, address);
+  const walletNotifiers = watchWallet(chainStorageWatcher, address, rpc);
 
   const makeOffer = async (
     invitationSpec,

--- a/packages/web-components/src/wallet-connection/watchWallet.js
+++ b/packages/web-components/src/wallet-connection/watchWallet.js
@@ -34,8 +34,9 @@ const POLL_INTERVAL_MS = 6000;
 /**
  * @param {any} chainStorageWatcher
  * @param {string} address
+ * @param {string} rpc
  */
-export const watchWallet = async (chainStorageWatcher, address) => {
+export const watchWallet = (chainStorageWatcher, address, rpc) => {
   const pursesNotifierKit = makeNotifierKit(
     /** @type {PurseInfo[] | null} */ (null),
   );
@@ -128,10 +129,7 @@ export const watchWallet = async (chainStorageWatcher, address) => {
       };
 
       const watchBank = async () => {
-        const balances = await queryBankBalances(
-          address,
-          chainStorageWatcher.rpcAddr,
-        );
+        const balances = await queryBankBalances(address, rpc);
         bank = balances;
         possiblyUpdateBankPurses();
         setTimeout(watchBank, POLL_INTERVAL_MS);
@@ -223,7 +221,7 @@ export const watchWallet = async (chainStorageWatcher, address) => {
   };
 
   const watchWalletUpdates = async () => {
-    const leader = makeLeader(chainStorageWatcher.rpcAddr);
+    const leader = makeLeader(rpc);
     const follower = makeFollower(`:published.wallet.${address}`, leader, {
       proof: 'none',
       unserializer: chainStorageWatcher.marshaller,

--- a/packages/web-components/test/walletConnection.test.js
+++ b/packages/web-components/test/walletConnection.test.js
@@ -13,6 +13,7 @@ import {
 } from '../src/wallet-connection/makeInteractiveSigner.js';
 
 const testAddress = 'agoric123test';
+const rpc = 'https://fake.rpc';
 
 // @ts-expect-error shim keplr
 // eslint-disable-next-line no-undef
@@ -43,17 +44,16 @@ describe('makeAgoricWalletConnection', () => {
   it('gets the address from keplr', async () => {
     const watcher = {
       chainId: 'agoric-foo',
-      rpcAddr: 'https://foo.agoric.net:443',
       watchLatest: (_path, onUpdate) => {
         onUpdate({ offerToPublicSubscriberPaths: 'foo' });
       },
     };
 
-    const connection = await makeAgoricWalletConnection(watcher);
+    const connection = await makeAgoricWalletConnection(watcher, rpc);
 
     expect(makeInteractiveSigner).toHaveBeenCalledWith(
       watcher.chainId,
-      watcher.rpcAddr,
+      rpc,
       // @ts-expect-error shim keplr
       window.keplr,
       SigningStargateClient.connectWithSigner,
@@ -64,7 +64,6 @@ describe('makeAgoricWalletConnection', () => {
   it('submits a spend action', async () => {
     const watcher = {
       chainId: 'agoric-foo',
-      rpcAddr: 'https://foo.agoric.net:443',
       watchLatest: (_path, onUpdate) => {
         onUpdate({ offerToPublicSubscriberPaths: 'foo' });
       },
@@ -73,7 +72,7 @@ describe('makeAgoricWalletConnection', () => {
       },
     };
 
-    const connection = await makeAgoricWalletConnection(watcher);
+    const connection = await makeAgoricWalletConnection(watcher, rpc);
 
     const onStatusChange = () => {
       expect(mockSubmitSpendAction).toHaveBeenCalledWith(
@@ -94,7 +93,6 @@ describe('makeAgoricWalletConnection', () => {
 it('submits a spend action', async () => {
   const watcher = {
     chainId: 'agoric-foo',
-    rpcAddr: 'https://foo.agoric.net:443',
     watchLatest: (_path, onUpdate) => {
       onUpdate({ offerToPublicSubscriberPaths: 'foo' });
     },
@@ -103,7 +101,7 @@ it('submits a spend action', async () => {
     },
   };
 
-  const connection = await makeAgoricWalletConnection(watcher);
+  const connection = await makeAgoricWalletConnection(watcher, rpc);
 
   connection.provisionSmartWallet();
   expect(mockProvisionSmartWallet).toHaveBeenCalled();


### PR DESCRIPTION
refs: https://github.com/Agoric/ui-kit/issues/53

For the chain storage watcher, no longer use the deprecated RPC method to query vstorage. Instead, use the JSON API. There's a lot of ways to handle the query logic, but for now this just keeps the same internal logic and makes a shotgun of requests instead of a batch query. Bandwidth consumption seems roughly similar after increasing the polling period a bit, and the increased request count should have minimal impact with [connection coalescing](https://daniel.haxx.se/blog/2016/08/18/http2-connection-coalescing/).

Also, updates the wallet connection component because it was relying on the watcher having an RPC node.

Updated unit tests and validated with https://github.com/Agoric/dapp-inter/pull/209 locally using yarn link