### PR TITLE
feat(web-components): surface wallet connection rpc errors

### DIFF
--- a/packages/web-components/src/wallet-connection/queryBankBalances.js
+++ b/packages/web-components/src/wallet-connection/queryBankBalances.js
@@ -1,0 +1,20 @@
+import { QueryClient, createProtobufRpcClient } from '@cosmjs/stargate';
+import { QueryClientImpl } from 'cosmjs-types/cosmos/bank/v1beta1/query';
+
+/** @typedef {import('@cosmjs/tendermint-rpc').Tendermint34Client} Tendermint34Client */
+
+/**
+ * @param {string} address
+ * @param {Tendermint34Client} tendermint
+ */
+export const queryBankBalances = async (address, tendermint) => {
+  const queryClient = new QueryClient(tendermint);
+  const rpcClient = createProtobufRpcClient(queryClient);
+  const bankQueryService = new QueryClientImpl(rpcClient);
+
+  const { balances } = await bankQueryService.AllBalances({
+    address,
+  });
+
+  return balances;
+};

--- a/packages/web-components/src/wallet-connection/walletConnection.js
+++ b/packages/web-components/src/wallet-connection/walletConnection.js
@@ -8,12 +8,12 @@ import { Errors } from '../errors.js';
 /**
  * @param {any} chainStorageWatcher
  * @param {string} rpc
- * @param {((error: unknown) => void)=} onRpcError
+ * @param {((error: unknown) => void)} [onError]
  */
 export const makeAgoricWalletConnection = async (
   chainStorageWatcher,
   rpc,
-  onRpcError = undefined,
+  onError = undefined,
 ) => {
   if (!('keplr' in window)) {
     throw Error(Errors.noKeplr);
@@ -34,7 +34,7 @@ export const makeAgoricWalletConnection = async (
     chainStorageWatcher,
     address,
     rpc,
-    onRpcError,
+    onError,
   );
 
   const makeOffer = async (

--- a/packages/web-components/src/wallet-connection/walletConnection.js
+++ b/packages/web-components/src/wallet-connection/walletConnection.js
@@ -5,7 +5,16 @@ import { makeInteractiveSigner } from './makeInteractiveSigner.js';
 import { watchWallet } from './watchWallet.js';
 import { Errors } from '../errors.js';
 
-export const makeAgoricWalletConnection = async (chainStorageWatcher, rpc) => {
+/**
+ * @param {any} chainStorageWatcher
+ * @param {string} rpc
+ * @param {((error: unknown) => void)=} onRpcError
+ */
+export const makeAgoricWalletConnection = async (
+  chainStorageWatcher,
+  rpc,
+  onRpcError = undefined,
+) => {
   if (!('keplr' in window)) {
     throw Error(Errors.noKeplr);
   }
@@ -21,7 +30,12 @@ export const makeAgoricWalletConnection = async (chainStorageWatcher, rpc) => {
       SigningStargateClient.connectWithSigner,
     );
 
-  const walletNotifiers = watchWallet(chainStorageWatcher, address, rpc);
+  const walletNotifiers = watchWallet(
+    chainStorageWatcher,
+    address,
+    rpc,
+    onRpcError,
+  );
 
   const makeOffer = async (
     invitationSpec,

--- a/packages/web-components/src/wallet-connection/watchWallet.js
+++ b/packages/web-components/src/wallet-connection/watchWallet.js
@@ -38,9 +38,16 @@ const MAX_ATTEMPTS_TO_WATCH_BANK = 2;
  * @param {any} chainStorageWatcher
  * @param {string} address
  * @param {string} rpc
- * @param {((error: unknown) => void)=} onRpcError
+ * @param {((error: unknown) => void)} [onError]
  */
-export const watchWallet = (chainStorageWatcher, address, rpc, onRpcError) => {
+export const watchWallet = (
+  chainStorageWatcher,
+  address,
+  rpc,
+  onError = () => {
+    /* noop */
+  },
+) => {
   const pursesNotifierKit = makeNotifierKit(
     /** @type {PurseInfo[] | null} */ (null),
   );
@@ -140,7 +147,7 @@ export const watchWallet = (chainStorageWatcher, address, rpc, onRpcError) => {
         } catch (e) {
           console.error('Error querying bank balances for address', address);
           if (attempts >= MAX_ATTEMPTS_TO_WATCH_BANK) {
-            onRpcError && onRpcError(e);
+            onError(new Error(`RPC error - ${e.toString?.()}`));
           } else {
             setTimeout(() => watchBank(attempts + 1), RETRY_INTERVAL_MS);
             return;
@@ -222,7 +229,7 @@ export const watchWallet = (chainStorageWatcher, address, rpc, onRpcError) => {
                 );
               } catch (e) {
                 console.error('Error getting boardAux for brands', brands, e);
-                onRpcError && onRpcError(e);
+                onError(new Error(`API error - ${e.toString?.()}`));
               }
             }
 
@@ -256,7 +263,7 @@ export const watchWallet = (chainStorageWatcher, address, rpc, onRpcError) => {
     try {
       await watch();
     } catch (e) {
-      onRpcError && onRpcError(e);
+      onError(new Error(`RPC error - ${e.toString?.()}`));
     }
   };
 

--- a/packages/web-components/src/wallet-connection/watchWallet.js
+++ b/packages/web-components/src/wallet-connection/watchWallet.js
@@ -2,7 +2,8 @@
 import { makeNotifierKit } from '@agoric/notifier';
 import { AmountMath } from '@agoric/ertp';
 import { iterateEach, makeFollower, makeLeader } from '@agoric/casting';
-import { queryBankBalances } from '../queryBankBalances.js';
+import { Tendermint34Client } from '@cosmjs/tendermint-rpc';
+import { queryBankBalances } from './queryBankBalances.js';
 
 /** @typedef {import('@agoric/smart-wallet/src/types.js').Petname} Petname */
 
@@ -30,13 +31,16 @@ import { queryBankBalances } from '../queryBankBalances.js';
  */
 
 const POLL_INTERVAL_MS = 6000;
+const RETRY_INTERVAL_MS = 200;
+const MAX_ATTEMPTS_TO_WATCH_BANK = 2;
 
 /**
  * @param {any} chainStorageWatcher
  * @param {string} address
  * @param {string} rpc
+ * @param {((error: unknown) => void)=} onRpcError
  */
-export const watchWallet = (chainStorageWatcher, address, rpc) => {
+export const watchWallet = (chainStorageWatcher, address, rpc, onRpcError) => {
   const pursesNotifierKit = makeNotifierKit(
     /** @type {PurseInfo[] | null} */ (null),
   );
@@ -125,9 +129,23 @@ export const watchWallet = (chainStorageWatcher, address, rpc) => {
         updatePurses(brandToPurse);
       };
 
-      const watchBank = async () => {
-        const balances = await queryBankBalances(address, rpc);
-        bank = balances;
+      /** @type {Tendermint34Client} */
+      let tendermintClient;
+      const watchBank = async (attempts = 0) => {
+        await null;
+
+        try {
+          tendermintClient ||= await Tendermint34Client.connect(rpc);
+          bank = await queryBankBalances(address, tendermintClient);
+        } catch (e) {
+          console.error('Error querying bank balances for address', address);
+          if (attempts >= MAX_ATTEMPTS_TO_WATCH_BANK) {
+            onRpcError && onRpcError(e);
+          } else {
+            setTimeout(() => watchBank(attempts + 1), RETRY_INTERVAL_MS);
+            return;
+          }
+        }
         possiblyUpdateBankPurses();
         setTimeout(watchBank, POLL_INTERVAL_MS);
       };
@@ -204,6 +222,7 @@ export const watchWallet = (chainStorageWatcher, address, rpc) => {
                 );
               } catch (e) {
                 console.error('Error getting boardAux for brands', brands, e);
+                onRpcError && onRpcError(e);
               }
             }
 
@@ -218,17 +237,26 @@ export const watchWallet = (chainStorageWatcher, address, rpc) => {
   };
 
   const watchWalletUpdates = async () => {
-    const leader = makeLeader(rpc);
-    const follower = makeFollower(`:published.wallet.${address}`, leader, {
-      proof: 'none',
-      unserializer: chainStorageWatcher.marshaller,
-    });
+    const watch = async () => {
+      const leader = makeLeader(rpc);
+      const follower = makeFollower(`:published.wallet.${address}`, leader, {
+        proof: 'none',
+        unserializer: chainStorageWatcher.marshaller,
+      });
 
-    for await (const update of iterateEach(follower)) {
-      console.debug('wallet update', update);
-      if ('error' in update) continue;
+      for await (const update of iterateEach(follower)) {
+        console.debug('wallet update', update);
+        if ('error' in update) continue;
 
-      walletUpdatesNotifierKit.updater.updateState(harden(update.value));
+        walletUpdatesNotifierKit.updater.updateState(harden(update.value));
+      }
+    };
+
+    await null;
+    try {
+      await watch();
+    } catch (e) {
+      onRpcError && onRpcError(e);
     }
   };
 


### PR DESCRIPTION
refs https://github.com/Agoric/agoric-sdk/issues/8505

We improved error handling to the `chainStorageWatcher` in https://github.com/Agoric/ui-kit/pull/65, but the `makeAgoricWalletConnection` component uses the RPC endpoint rather than the API endpoint, and doesn't surface errors conveniently when queries fail. This adds an `onRpcError` parameter so that clients can respond accordingly when the RPC node is failing.

Also, made it only call `await Tendermint34Client.connect(rpc)` once instead of every time it queries the bank. This removes an [extra round trip](https://github.com/cosmos/cosmjs/blob/97a54b8a101263b75faceadcd0462a2f3f265103/packages/tendermint-rpc/src/tendermint34/tendermint34client.ts#L42) to reduce load on the RPC node. Also added up to 2 retries around `queryBank` because the tendermint client doesn't do any retries on its own.