### PR TITLE
Fix provision status bug

### DIFF
--- a/packages/rpc/src/chainStorageWatcher.ts
+++ b/packages/rpc/src/chainStorageWatcher.ts
@@ -108,7 +108,8 @@ export const makeAgoricChainStorageWatcher = (
       (blockHeight === latestValueIdentifier ||
         // Blockheight is undefined so fallback to using the stringified value
         // as the identifier, as is the case for `children` queries.
-        (blockHeight === undefined && JSON.stringify(value) === latestValue))
+        (blockHeight === undefined &&
+          (value === latestValue || JSON.stringify(value) === latestValue)))
     ) {
       // The value isn't new, don't emit.
       queueNextRefresh();

--- a/packages/web-components/src/wallet-connection/watchWallet.js
+++ b/packages/web-components/src/wallet-connection/watchWallet.js
@@ -85,11 +85,13 @@ export const watchWallet = (
   chainStorageWatcher.watchLatest(
     ['data', `published.wallet.${address}.current`],
     value => {
-      if (!value && !isWalletMissing) {
-        smartWalletStatusNotifierKit.updater.updateState(
-          harden({ provisioned: false }),
-        );
-        isWalletMissing = true;
+      if (!value) {
+        if (!isWalletMissing) {
+          smartWalletStatusNotifierKit.updater.updateState(
+            harden({ provisioned: false }),
+          );
+          isWalletMissing = true;
+        }
         return;
       }
 


### PR DESCRIPTION
The provision status for non-provisioned accounts was coming back as `provisioned: false` initially, but the next time it polled the status, it would treat the empty string value `""` as a new value because it was comparing it to the `JSON.stringify` result of `'""'` which is different. This was a bug in `@agoric/rpc` because of the redundant update, which also exposed a bug in `@agoric/web-components` because it was always reporting the status as `provisioned: true` for subsequent updates, no matter what the value was. Fixed both.