### PR TITLE
feat: include slot in synthesized remotable label

### DIFF
--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -23,6 +23,7 @@
     "vite-tsconfig-paths": "^4.2.0"
   },
   "devDependencies": {
+    "@endo/init": "^0.5.60",
     "@typescript-eslint/eslint-plugin": "^5.35.1",
     "@typescript-eslint/parser": "^5.35.1",
     "@vitest/coverage-c8": "^0.25.3",

--- a/packages/rpc/src/marshal.ts
+++ b/packages/rpc/src/marshal.ts
@@ -27,8 +27,8 @@ const makeTranslationTable = (
   return harden({ convertValToSlot, convertSlotToVal });
 };
 
-const synthesizeRemotable = (_slot: unknown, iface: string | undefined) =>
-  Far((iface ?? '').replace(/^Alleged: /, ''), {});
+const synthesizeRemotable = (slot: unknown, iface: string | undefined) =>
+  Far(`${(iface ?? '').replace(/^Alleged: /, '')}#${slot}`, {});
 
 const { convertValToSlot, convertSlotToVal } = makeTranslationTable(slot => {
   throw new Error(`unknown id: ${slot}`);

--- a/packages/rpc/test/marshal.test.ts
+++ b/packages/rpc/test/marshal.test.ts
@@ -1,0 +1,10 @@
+import '@endo/init'; // UNTIL https://github.com/endojs/endo/issues/1686
+import { expect, test } from 'vitest';
+import { makeClientMarshaller } from '../src/marshal.js';
+
+test('inclue boardIDs in string version of synthetic remotables', () => {
+  const m = makeClientMarshaller();
+  const capData = { body: '#"$0.Brand"', slots: ['board0123'] };
+  const str = String(m.fromCapData(capData));
+  expect(str).toBe('[object Alleged: Brand#board0123]');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,11 +24,6 @@
   resolved "https://registry.yarnpkg.com/@agoric/assert/-/assert-0.6.1-dev-8c14632.0.tgz#10508f092798c92c960620103e9bbb47caf9b21e"
   integrity sha512-DeVZy/OhbGBgvFAc9/+a2KK2s7tSjwoY1jX0bRQQVCNcIVPzpxLi9+7BqNl+GVw8o/zkWf5EjnZVT6ovflXMVA==
 
-"@agoric/assert@0.6.1-dev-b8d6697.0+b8d6697":
-  version "0.6.1-dev-b8d6697.0"
-  resolved "https://registry.yarnpkg.com/@agoric/assert/-/assert-0.6.1-dev-b8d6697.0.tgz#8c9b13a2add66e99b52a13bccbc0c817823acf40"
-  integrity sha512-9tNjD7qXGDoMS6eJqn6eQdh9nARiPoLASpZHUi0dFz9Ptub7+hIdcoGp5lXiKlGtIBhFmQv0QJZ6F1gxv9XdYA==
-
 "@agoric/assert@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@agoric/assert/-/assert-0.6.0.tgz#43ede53cf0943f3e9038f597f776e52500446e41"
@@ -187,20 +182,6 @@
     anylogger "^0.21.0"
     jessie.js "^0.3.2"
 
-"@agoric/internal@0.3.3-dev-b8d6697.0+b8d6697":
-  version "0.3.3-dev-b8d6697.0"
-  resolved "https://registry.yarnpkg.com/@agoric/internal/-/internal-0.3.3-dev-b8d6697.0.tgz#f36e01571d27bd1320fbdc67f3a5ce6c7dbfed8d"
-  integrity sha512-aD6nlDXgi7ggMLJRrPLd+FoymNTfxP0crsdY9QsKZDayOGnOPQWOjaQmRKU4MGWOejUwyvBpiD9Y1FMDSYRfKg==
-  dependencies:
-    "@agoric/zone" "0.2.3-dev-b8d6697.0+b8d6697"
-    "@endo/far" "^0.2.18"
-    "@endo/marshal" "^0.8.5"
-    "@endo/patterns" "^0.2.2"
-    "@endo/promise-kit" "^0.2.56"
-    "@endo/stream" "^0.3.25"
-    anylogger "^0.21.0"
-    jessie.js "^0.3.2"
-
 "@agoric/internal@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@agoric/internal/-/internal-0.3.2.tgz#a1242947083ab46cbd34613add8bacbd0c9dc443"
@@ -244,22 +225,7 @@
     "@endo/marshal" "^0.8.5"
     "@endo/promise-kit" "^0.2.56"
 
-"@agoric/notifier@^0.6.3-dev-8c14632.0":
-  version "0.6.3-dev-b8d6697.0"
-  resolved "https://registry.yarnpkg.com/@agoric/notifier/-/notifier-0.6.3-dev-b8d6697.0.tgz#9a32cb0a7ef4a5ccf11a47b0ab4f409b6907235e"
-  integrity sha512-NcUIbpQhIMnZR7JU0UMd3m/4NdE2s/c27N7sLpLElIjgVQk8seuOzqNcZ2Jh+dtHBhMRphDdUgQfPwNk9S29Gg==
-  dependencies:
-    "@agoric/assert" "0.6.1-dev-b8d6697.0+b8d6697"
-    "@agoric/internal" "0.3.3-dev-b8d6697.0+b8d6697"
-    "@agoric/store" "0.9.3-dev-b8d6697.0+b8d6697"
-    "@agoric/swing-store" "0.9.2-dev-b8d6697.0+b8d6697"
-    "@agoric/swingset-vat" "0.32.3-dev-b8d6697.0+b8d6697"
-    "@agoric/vat-data" "0.5.3-dev-b8d6697.0+b8d6697"
-    "@endo/far" "^0.2.18"
-    "@endo/marshal" "^0.8.5"
-    "@endo/promise-kit" "^0.2.56"
-
-"@agoric/notifier@^0.6.3-u13.0":
+"@agoric/notifier@^0.6.3-dev-8c14632.0", "@agoric/notifier@^0.6.3-u13.0":
   version "0.6.3-u13.0"
   resolved "https://registry.yarnpkg.com/@agoric/notifier/-/notifier-0.6.3-u13.0.tgz#fe9bfd05dd3bb2af459ef44e231ddacc995c4cf8"
   integrity sha512-H/DOZ6KY/c+k+aWAT0vOnlO+vtSJlO7XKK8TMDImxExzRNZ0AXyTHVfLgPBmoUaqCxx6d9tupN7Do25PBvvPHg==
@@ -334,17 +300,6 @@
     "@endo/pass-style" "^0.1.3"
     "@endo/patterns" "^0.2.2"
 
-"@agoric/store@0.9.3-dev-b8d6697.0+b8d6697":
-  version "0.9.3-dev-b8d6697.0"
-  resolved "https://registry.yarnpkg.com/@agoric/store/-/store-0.9.3-dev-b8d6697.0.tgz#f2914d7d2391319f0b00ad3655b005afd263eb81"
-  integrity sha512-uuQsxHrv0AnabrfKrBSz1tBzsw1XsK0+gqg7igEiRemcP2OAGhnpDI2xygRAqTvJDfakYl5g2eQHATtlUB+hmA==
-  dependencies:
-    "@agoric/assert" "0.6.1-dev-b8d6697.0+b8d6697"
-    "@endo/exo" "^0.2.2"
-    "@endo/marshal" "^0.8.5"
-    "@endo/pass-style" "^0.1.3"
-    "@endo/patterns" "^0.2.2"
-
 "@agoric/store@^0.9.2":
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/@agoric/store/-/store-0.9.2.tgz#0973e57b8811a70923c141fccfb002bbad8fed4b"
@@ -372,19 +327,6 @@
     "@endo/pass-style" "0.1.3"
     "@endo/patterns" "0.2.2"
 
-"@agoric/swing-store@0.9.2-dev-b8d6697.0+b8d6697":
-  version "0.9.2-dev-b8d6697.0"
-  resolved "https://registry.yarnpkg.com/@agoric/swing-store/-/swing-store-0.9.2-dev-b8d6697.0.tgz#c99ad5abff8e76dd4fb5d18ee864bac14196381f"
-  integrity sha512-/oZXrM2jhfBk1VZ91JcmQ9MPdIgwqVUD4hMjam511nWlxyokWznBLQDO0oBLsmCm8FL5y8EfFya/0ArxeegB6A==
-  dependencies:
-    "@agoric/assert" "0.6.1-dev-b8d6697.0+b8d6697"
-    "@agoric/internal" "0.3.3-dev-b8d6697.0+b8d6697"
-    "@endo/base64" "^0.2.31"
-    "@endo/bundle-source" "^2.5.1"
-    "@endo/check-bundle" "^0.2.18"
-    "@endo/nat" "^4.1.27"
-    better-sqlite3 "^8.2.0"
-
 "@agoric/swing-store@^0.9.1":
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/@agoric/swing-store/-/swing-store-0.9.1.tgz#0ed85beac7a7cd2e8e7507ea58e50eecb08a203e"
@@ -411,7 +353,7 @@
     "@endo/nat" "4.1.27"
     better-sqlite3 "^8.2.0"
 
-"@agoric/swingset-liveslots@0.10.3-dev-8c14632.0", "@agoric/swingset-liveslots@0.10.3-dev-b8d6697.0+b8d6697", "@agoric/swingset-liveslots@^0.10.2", "@agoric/swingset-liveslots@^0.10.3-u13.0":
+"@agoric/swingset-liveslots@0.10.3-dev-8c14632.0", "@agoric/swingset-liveslots@^0.10.2", "@agoric/swingset-liveslots@^0.10.3-u13.0":
   version "0.10.3-dev-8c14632.0"
   resolved "https://registry.yarnpkg.com/@agoric/swingset-liveslots/-/swingset-liveslots-0.10.3-dev-8c14632.0.tgz#88334dc83f69ff14748e1ea96787b7dcf046009b"
   integrity sha512-RthFdS0ekd9fKfSd2cDZeoUEORduPEVAUwx27lEad2t3HN8ERwmhZ4F3QCb0BsO+nFe2Svtu8haXdgAuibkwnA==
@@ -429,42 +371,6 @@
     "@endo/pass-style" "^0.1.3"
     "@endo/patterns" "^0.2.2"
     "@endo/promise-kit" "^0.2.56"
-
-"@agoric/swingset-vat@0.32.3-dev-b8d6697.0+b8d6697":
-  version "0.32.3-dev-b8d6697.0"
-  resolved "https://registry.yarnpkg.com/@agoric/swingset-vat/-/swingset-vat-0.32.3-dev-b8d6697.0.tgz#0966258e1d5dffb4a66b5bf4b59c8983efbb9c6b"
-  integrity sha512-fkPTl9o8dwSw3PeNcsGg8SpJku+cYhtSMnpG2JxQrZOB7PaEHlPn3apFa8GaLuGp+z0IcDx9e/PW/ccdpTvulA==
-  dependencies:
-    "@agoric/assert" "0.6.1-dev-b8d6697.0+b8d6697"
-    "@agoric/internal" "0.3.3-dev-b8d6697.0+b8d6697"
-    "@agoric/store" "0.9.3-dev-b8d6697.0+b8d6697"
-    "@agoric/swing-store" "0.9.2-dev-b8d6697.0+b8d6697"
-    "@agoric/swingset-liveslots" "0.10.3-dev-b8d6697.0+b8d6697"
-    "@agoric/swingset-xsnap-supervisor" "0.10.3-dev-b8d6697.0+b8d6697"
-    "@agoric/time" "0.3.3-dev-b8d6697.0+b8d6697"
-    "@agoric/vat-data" "0.5.3-dev-b8d6697.0+b8d6697"
-    "@agoric/xsnap" "0.14.3-dev-b8d6697.0+b8d6697"
-    "@agoric/xsnap-lockdown" "0.14.1-dev-b8d6697.0+b8d6697"
-    "@endo/base64" "^0.2.31"
-    "@endo/bundle-source" "^2.5.1"
-    "@endo/captp" "^3.1.1"
-    "@endo/check-bundle" "^0.2.18"
-    "@endo/compartment-mapper" "^0.8.4"
-    "@endo/eventual-send" "^0.17.2"
-    "@endo/far" "^0.2.18"
-    "@endo/import-bundle" "^0.3.4"
-    "@endo/init" "^0.5.56"
-    "@endo/marshal" "^0.8.5"
-    "@endo/nat" "^4.1.27"
-    "@endo/promise-kit" "^0.2.56"
-    "@endo/ses-ava" "^0.2.40"
-    "@endo/zip" "^0.2.31"
-    ansi-styles "^6.2.1"
-    anylogger "^0.21.0"
-    import-meta-resolve "^2.2.1"
-    microtime "^3.1.0"
-    semver "^6.3.0"
-    tmp "^0.2.1"
 
 "@agoric/swingset-vat@^0.32.2":
   version "0.32.2"
@@ -537,11 +443,6 @@
     semver "^6.3.0"
     tmp "^0.2.1"
 
-"@agoric/swingset-xsnap-supervisor@0.10.3-dev-b8d6697.0+b8d6697":
-  version "0.10.3-dev-b8d6697.0"
-  resolved "https://registry.yarnpkg.com/@agoric/swingset-xsnap-supervisor/-/swingset-xsnap-supervisor-0.10.3-dev-b8d6697.0.tgz#921f5d79f7a22acc1c11860aa2cf79e03a3f8973"
-  integrity sha512-60tlupkjyQSLLmrIxX1mwUKcs0W3FV9FH8iClz4pAqAdyV77Vb5joI5ItqLsIw/+u+jU43wVOwj50uALKO0oDw==
-
 "@agoric/swingset-xsnap-supervisor@^0.10.2":
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/@agoric/swingset-xsnap-supervisor/-/swingset-xsnap-supervisor-0.10.2.tgz#09f067695b0ea6ebfeb6ea200cc7f1675f0f8939"
@@ -551,15 +452,6 @@
   version "0.10.3-u13.0"
   resolved "https://registry.yarnpkg.com/@agoric/swingset-xsnap-supervisor/-/swingset-xsnap-supervisor-0.10.3-u13.0.tgz#83c7744c28b0093a93ef1dbdf3e3c7244dbf5265"
   integrity sha512-gEIOlyLd34JZkVRPWq9982Eu7G4ggE6H3I3RueO9JbbhOXwU+irYL922t0Ztdjc9aJW2H5f78ukcn9j1SZmtHQ==
-
-"@agoric/time@0.3.3-dev-b8d6697.0+b8d6697":
-  version "0.3.3-dev-b8d6697.0"
-  resolved "https://registry.yarnpkg.com/@agoric/time/-/time-0.3.3-dev-b8d6697.0.tgz#2b777bdab4837c7aafe78bb3e8165ea0b6bf2b85"
-  integrity sha512-86slV6k1Wvf3+AI5djQSZT5c1Yo0o03ZpkrHglcWkbLDCVBcgi+JFPdo17/n4WwrTMX/fgqFidq8MhMuicRq7w==
-  dependencies:
-    "@agoric/assert" "0.6.1-dev-b8d6697.0+b8d6697"
-    "@agoric/store" "0.9.3-dev-b8d6697.0+b8d6697"
-    "@endo/nat" "^4.1.27"
 
 "@agoric/time@^0.3.2":
   version "0.3.2"
@@ -587,15 +479,6 @@
     "@agoric/assert" "0.6.1-dev-8c14632.0+8c14632"
     "@agoric/internal" "0.3.3-dev-8c14632.0+8c14632"
     "@agoric/store" "0.9.3-dev-8c14632.0+8c14632"
-
-"@agoric/vat-data@0.5.3-dev-b8d6697.0+b8d6697":
-  version "0.5.3-dev-b8d6697.0"
-  resolved "https://registry.yarnpkg.com/@agoric/vat-data/-/vat-data-0.5.3-dev-b8d6697.0.tgz#32df469b7a0e115f475929069e372fb2239b2366"
-  integrity sha512-Vw6AljspZfWlXmj+D9d+I42QanES7sh4iN70AGGGDvlqKlrk2l5tx6Ky4UeJFlLdQtpyc4j3pb/SFKGl2FInRQ==
-  dependencies:
-    "@agoric/assert" "0.6.1-dev-b8d6697.0+b8d6697"
-    "@agoric/internal" "0.3.3-dev-b8d6697.0+b8d6697"
-    "@agoric/store" "0.9.3-dev-b8d6697.0+b8d6697"
 
 "@agoric/vat-data@^0.5.2":
   version "0.5.2"
@@ -657,11 +540,6 @@
     eslint-plugin-eslint-comments "^3.1.2"
     import-meta-resolve "^2.2.1"
 
-"@agoric/xsnap-lockdown@0.14.1-dev-b8d6697.0+b8d6697":
-  version "0.14.1-dev-b8d6697.0"
-  resolved "https://registry.yarnpkg.com/@agoric/xsnap-lockdown/-/xsnap-lockdown-0.14.1-dev-b8d6697.0.tgz#adc5058c0f3281388649841e658d9ab422dd1cda"
-  integrity sha512-p+PlAHbBTDfJTpUqKXjHWChWaEDDrtye7Hdh78anpHHNSMyih2zGljmx24oe6cKJhwjzDsfAxaPcdmq0rteIvg==
-
 "@agoric/xsnap-lockdown@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@agoric/xsnap-lockdown/-/xsnap-lockdown-0.14.0.tgz#0c605bbd08e6ccf1954a615dbce7d4c0fe578a32"
@@ -671,24 +549,6 @@
   version "0.14.1-u13.0"
   resolved "https://registry.yarnpkg.com/@agoric/xsnap-lockdown/-/xsnap-lockdown-0.14.1-u13.0.tgz#0bc11a4d19d02a77cd9158dda3877c2ddc1ef8d4"
   integrity sha512-CUd4u1vyqSJfxj2+krNMBmDXlR7yN87RJsmB03ISPs8GuhjIrbdgkU+UfoKIJFLYco2ZSX7vR9j8l6azyVan1Q==
-
-"@agoric/xsnap@0.14.3-dev-b8d6697.0+b8d6697":
-  version "0.14.3-dev-b8d6697.0"
-  resolved "https://registry.yarnpkg.com/@agoric/xsnap/-/xsnap-0.14.3-dev-b8d6697.0.tgz#a00d0b8f4d42b292b513b2a86c658895155c3a8a"
-  integrity sha512-TA5gv99HBJIOao/oJ7XbvECNyVt2u0WvevqXd9XkxJ9RaBew1s0qgSggUNiqWpJ/EAmTjK1+h81CVPPOlh7Ggw==
-  dependencies:
-    "@agoric/assert" "0.6.1-dev-b8d6697.0+b8d6697"
-    "@agoric/internal" "0.3.3-dev-b8d6697.0+b8d6697"
-    "@agoric/xsnap-lockdown" "0.14.1-dev-b8d6697.0+b8d6697"
-    "@endo/bundle-source" "^2.5.1"
-    "@endo/eventual-send" "^0.17.2"
-    "@endo/init" "^0.5.56"
-    "@endo/netstring" "^0.3.26"
-    "@endo/promise-kit" "^0.2.56"
-    "@endo/stream" "^0.3.25"
-    "@endo/stream-node" "^0.2.26"
-    glob "^7.1.6"
-    tmp "^0.2.1"
 
 "@agoric/xsnap@^0.14.2":
   version "0.14.2"
@@ -756,15 +616,6 @@
   dependencies:
     "@agoric/store" "0.9.3-dev-8c14632.0+8c14632"
     "@agoric/vat-data" "0.5.3-dev-8c14632.0+8c14632"
-    "@endo/far" "^0.2.18"
-
-"@agoric/zone@0.2.3-dev-b8d6697.0+b8d6697":
-  version "0.2.3-dev-b8d6697.0"
-  resolved "https://registry.yarnpkg.com/@agoric/zone/-/zone-0.2.3-dev-b8d6697.0.tgz#a657928435360ac6f1e3ca3538b83146b5d52d8d"
-  integrity sha512-jfU6t27t4mSU1OuTuMOIi42X3jci7sJBrS8WT904cGd527lC+Ffu4wdL9HV+ZW+7WTE9zQ07rVAnmu5drwFMmQ==
-  dependencies:
-    "@agoric/store" "0.9.3-dev-b8d6697.0+b8d6697"
-    "@agoric/vat-data" "0.5.3-dev-b8d6697.0+b8d6697"
     "@endo/far" "^0.2.18"
 
 "@agoric/zone@^0.2.2":
@@ -2197,10 +2048,15 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@endo/base64@0.2.31", "@endo/base64@^0.2.31":
+"@endo/base64@0.2.31":
   version "0.2.31"
   resolved "https://registry.yarnpkg.com/@endo/base64/-/base64-0.2.31.tgz#92378462cd791e0258a2291d44d2cfd15415cf32"
   integrity sha512-7IndkaZ7buIuFw8oBovNZV7epuyFWs0gdusSJ/zrx6fMXRqX0ycSTtxr6M5xADQGss1I9fqP3vteVLiNFlyIbw==
+
+"@endo/base64@^0.2.31", "@endo/base64@^0.2.35":
+  version "0.2.35"
+  resolved "https://registry.yarnpkg.com/@endo/base64/-/base64-0.2.35.tgz#7d18203d5807748388c935df7eb79c7672a0b64e"
+  integrity sha512-rsAicKvgNq/ar+9b3ElXRXglMiJcg1IErz3lx1HFYZUzfWp8r/Dibi3TEjYpSBmtOeYN9CeWH8CBluN0uFqdag==
 
 "@endo/bundle-source@2.5.2-upstream-rollup":
   version "2.5.2-upstream-rollup"
@@ -2324,7 +2180,7 @@
     "@endo/base64" "^0.2.31"
     "@endo/compartment-mapper" "^0.8.4"
 
-"@endo/init@0.5.56", "@endo/init@^0.5.56":
+"@endo/init@0.5.56":
   version "0.5.56"
   resolved "https://registry.yarnpkg.com/@endo/init/-/init-0.5.56.tgz#c241de519434309f362dc676e76ee36c93240151"
   integrity sha512-BKA7O2uy9uaGw9dB9X515SIaTumaO58HD30AXkJllW6bmLM/BxxFM3GCgS127x0Wot1ni32Y0DxkwxdEXFXJEQ==
@@ -2334,12 +2190,29 @@
     "@endo/lockdown" "^0.1.28"
     "@endo/promise-kit" "^0.2.56"
 
-"@endo/lockdown@0.1.28", "@endo/lockdown@^0.1.28":
+"@endo/init@^0.5.56", "@endo/init@^0.5.60":
+  version "0.5.60"
+  resolved "https://registry.yarnpkg.com/@endo/init/-/init-0.5.60.tgz#e78051b13cd4a04c72d5ec1d2a6011b7f987f7ff"
+  integrity sha512-AbAvs6Nk01fyJ+PaW0RzwemIWyomjzDf8ZEhVa3jCOhr8kBBsTnJdX0v7XkbZ/Y8NQxlrFaW0fPqlJK6aMWTlQ==
+  dependencies:
+    "@endo/base64" "^0.2.35"
+    "@endo/eventual-send" "^0.17.6"
+    "@endo/lockdown" "^0.1.32"
+    "@endo/promise-kit" "^0.2.60"
+
+"@endo/lockdown@0.1.28":
   version "0.1.28"
   resolved "https://registry.yarnpkg.com/@endo/lockdown/-/lockdown-0.1.28.tgz#43f23dcbb12b6ebd3ad2a3dc8c6bb3609dd9e95f"
   integrity sha512-YqurtDU23+0kuWq4J2c94HyRB1aqSB8xEwrx5xTZA9IY/anrtppEiTFGU8tQXqZFhE6bfRzSGWDIVKaXCcm4Lw==
   dependencies:
     ses "^0.18.4"
+
+"@endo/lockdown@^0.1.28", "@endo/lockdown@^0.1.32":
+  version "0.1.32"
+  resolved "https://registry.yarnpkg.com/@endo/lockdown/-/lockdown-0.1.32.tgz#2d13a9ca336d5dce243a3cf919c543b55973153c"
+  integrity sha512-AN696XS3robsopxVg7gc/6c9TXPGosGmKfcM0g9SNnD1rqgo1EakS4wf7f3AbICU9iJdo0e4V5JjzWPnjqoR0g==
+  dependencies:
+    ses "^0.18.8"
 
 "@endo/marshal@0.8.5":
   version "0.8.5"
@@ -4596,16 +4469,7 @@ axios@^0.27.2:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
 
-axios@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
-  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
-  dependencies:
-    follow-redirects "^1.15.0"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
-axios@^1.6.2:
+axios@^1.0.0, axios@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
   integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==


### PR DESCRIPTION
## Description

include slot (usually boardID) in label of synthetic remotables

for example: `[object Alleged: Brand#board0123]` instead of just `[object Alleged: Brand]`

### Security Considerations

Some similar things can only be done for debugging because otherwise they divulge info to parties that shouldn't have it.
But I believe it's OK in this context even in production: the client already knows the boardID.

### Scaling Considerations

n/a

### Documentation Considerations

I expect this to enhance clarity in some situations. (I hope to contribute something similar to the vstorage viewer.)

I don't consider these labels to be part of the API, so I do **not** consider this a breaking change.
I'm not aware of any clients that depend on the string form of these labels. Feedback from reviewers on this is particularly welcome, in any case.

### Testing Considerations

one straightforward unit test is included. seems sufficient for such a small change

This does add `@endo/init` to devDependencies of rcp to use `@endo/marshal` in the test.
