### PR TITLE
feat(chainStorageWatcher): enable non-browser compatability

### DIFF
--- a/packages/rpc/src/chainStorageWatcher.ts
+++ b/packages/rpc/src/chainStorageWatcher.ts
@@ -71,14 +71,17 @@ export const makeAgoricChainStorageWatcher = (
   >();
 
   const watchedPathsToSubscribers = new Map<string, Set<Subscriber<unknown>>>();
-  const watchedPathsToRefreshTimeouts = new Map<string, number>();
+  const watchedPathsToRefreshTimeouts = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
 
   const refreshDataForPath = async (
     path: [AgoricChainStoragePathKind, string],
   ) => {
     const queueNextRefresh = () => {
-      window.clearTimeout(watchedPathsToRefreshTimeouts.get(pathKey));
-      const timeout = window.setTimeout(
+      globalThis.clearTimeout(watchedPathsToRefreshTimeouts.get(pathKey));
+      const timeout = globalThis.setTimeout(
         () => refreshDataForPath(path),
         randomRefreshPeriod(refreshLowerBoundMs, refreshUpperBoundMs),
       );
@@ -141,7 +144,7 @@ export const makeAgoricChainStorageWatcher = (
     if (subscribersForPath.size === 1) {
       watchedPathsToSubscribers.delete(pathKey);
       latestValueCache.delete(pathKey);
-      window.clearTimeout(watchedPathsToRefreshTimeouts.get(pathKey));
+      globalThis.clearTimeout(watchedPathsToRefreshTimeouts.get(pathKey));
       watchedPathsToRefreshTimeouts.delete(pathKey);
     } else {
       subscribersForPath.delete(subscriber);


### PR DESCRIPTION
closes: #XXXX
refs: #47

## Description

Replaces `window.(set|clear)Timeout()` with `globalThis.(set|clear)Timeout()` so this export can be used in Node.js.

### Security Considerations

This change might involve ambient authority (globalThis), but this authority was already present in the original implementation.

### Scaling Considerations

N/A

### Documentation Considerations

When #47 is closed, we should update docs to explain Node.js support. 

### Testing Considerations

Existing tests should cover these changes.
