### PR TITLE
fix ESM compat

### DIFF
--- a/packages/rpc/index.ts
+++ b/packages/rpc/index.ts
@@ -1,3 +1,3 @@
 /* eslint-disable import/extensions */
-export * from './src/chainStorageWatcher';
-export * from './src/types';
+export * from './src/chainStorageWatcher.js';
+export * from './src/types.js';

--- a/packages/rpc/src/chainStorageWatcher.ts
+++ b/packages/rpc/src/chainStorageWatcher.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-use-before-define */
 /* eslint-disable import/extensions */
-import { makeClientMarshaller } from './marshal';
-import { AgoricChainStoragePathKind } from './types';
-import { vstorageQuery, keyToPath, pathToKey } from './vstorageQuery';
-import type { UpdateHandler } from './types';
+import { makeClientMarshaller } from './marshal.js';
+import { AgoricChainStoragePathKind } from './types.js';
+import { vstorageQuery, pathToKey } from './vstorageQuery.js';
+import type { UpdateHandler } from './types.js';
 
 type Subscriber<T> = {
   onUpdate: UpdateHandler<T>;

--- a/packages/rpc/src/vstorageQuery.ts
+++ b/packages/rpc/src/vstorageQuery.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import axiosRetry from 'axios-retry';
 import type { FromCapData } from '@endo/marshal';
-import { AgoricChainStoragePathKind } from './types';
+import { AgoricChainStoragePathKind } from './types.js';
 
 export const pathToKey = (path: [AgoricChainStoragePathKind, string]) =>
   path.join('.');

--- a/packages/rpc/test/chainStorageWatcher.test.ts
+++ b/packages/rpc/test/chainStorageWatcher.test.ts
@@ -2,9 +2,9 @@
 /* eslint-disable import/extensions */
 import { expect, it, describe, beforeEach, vi, afterEach } from 'vitest';
 import MockAdapter from 'axios-mock-adapter';
-import { makeAgoricChainStorageWatcher } from '../src/chainStorageWatcher';
-import { axiosClient } from '../src/vstorageQuery';
-import { AgoricChainStoragePathKind } from '../src/types';
+import { makeAgoricChainStorageWatcher } from '../src/chainStorageWatcher.js';
+import { axiosClient } from '../src/vstorageQuery.js';
+import { AgoricChainStoragePathKind } from '../src/types.js';
 
 global.harden = val => val;
 

--- a/packages/rpc/vitest.config.ts
+++ b/packages/rpc/vitest.config.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/extensions */
 import { mergeConfig } from 'vite';
 import { defineConfig } from 'vitest/config';
-import viteConfig from './vite.config';
+import viteConfig from './vite.config.js';
 
 export default mergeConfig(
   viteConfig,

--- a/packages/web-components/src/dapp-wallet-bridge/DappWalletBridge.js
+++ b/packages/web-components/src/dapp-wallet-bridge/DappWalletBridge.js
@@ -3,7 +3,7 @@ import { html, LitElement } from 'lit';
 import { assert, details as X } from '@agoric/assert';
 
 // Ambient types. https://github.com/Agoric/agoric-sdk/issues/6512
-import '@agoric/zoe/src/zoeService/types';
+import '@agoric/zoe/src/zoeService/types.js';
 
 // This site tells the component the URL to load the wallet bridge from. For
 // development, the form on this site can be changed to point the dapp to a


### PR DESCRIPTION
## Description

@0xpatrickdev ran into,
```
Error: Cannot find module '/Users/0xpatrick/repos/dapp-offer-up/node_modules/@agoric/rpc/dist/src/chainStorageWatcher' imported from /Users/0xpatrick/repos/dapp-offer-up/node_modules/@agoric/rpc/dist/index.js
```

and suggested the packages shoudl be compatible with ESM.  I think this PR fixes that, though I don't know a good way to include a regression test.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
