### PR TITLE
ci: require js extensions on local imports

### DIFF
--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -30,10 +30,19 @@
     "axios-mock-adapter": "^1.22.0",
     "eslint": "^8.22.0",
     "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-require-extensions": "^0.1.3",
     "happy-dom": "^9.20.3",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.7.1",
     "typescript": "^5.1.3",
     "vitest": "^0.34.1"
+  },
+  "eslintConfig": {
+    "extends": [
+      "plugin:require-extensions/recommended"
+    ],
+    "plugins": [
+        "require-extensions"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,11 +19,6 @@
     n-readlines "^1.0.0"
     tmp "^0.2.1"
 
-"@agoric/assert@0.6.1-dev-8c14632.0+8c14632":
-  version "0.6.1-dev-8c14632.0"
-  resolved "https://registry.yarnpkg.com/@agoric/assert/-/assert-0.6.1-dev-8c14632.0.tgz#10508f092798c92c960620103e9bbb47caf9b21e"
-  integrity sha512-DeVZy/OhbGBgvFAc9/+a2KK2s7tSjwoY1jX0bRQQVCNcIVPzpxLi9+7BqNl+GVw8o/zkWf5EjnZVT6ovflXMVA==
-
 "@agoric/assert@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@agoric/assert/-/assert-0.6.0.tgz#43ede53cf0943f3e9038f597f776e52500446e41"
@@ -168,20 +163,6 @@
     agoric "^0.21.1"
     jessie.js "^0.3.2"
 
-"@agoric/internal@0.3.3-dev-8c14632.0+8c14632":
-  version "0.3.3-dev-8c14632.0"
-  resolved "https://registry.yarnpkg.com/@agoric/internal/-/internal-0.3.3-dev-8c14632.0.tgz#3717ca4e6afbc18facd8e554a86ad2f79cb7430b"
-  integrity sha512-d7VgxIV22PLdqCldIIycf6bGNx16K6wLG3ZQl21DGNzPSnoJPUh9WJ3e0w8h7utxmDYisqKLosG7ZWRWY+SY2A==
-  dependencies:
-    "@agoric/zone" "0.2.3-dev-8c14632.0+8c14632"
-    "@endo/far" "^0.2.18"
-    "@endo/marshal" "^0.8.5"
-    "@endo/patterns" "^0.2.2"
-    "@endo/promise-kit" "^0.2.56"
-    "@endo/stream" "^0.3.25"
-    anylogger "^0.21.0"
-    jessie.js "^0.3.2"
-
 "@agoric/internal@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@agoric/internal/-/internal-0.3.2.tgz#a1242947083ab46cbd34613add8bacbd0c9dc443"
@@ -289,17 +270,6 @@
     "@endo/import-bundle" "0.3.4"
     "@endo/marshal" "0.8.5"
 
-"@agoric/store@0.9.3-dev-8c14632.0+8c14632":
-  version "0.9.3-dev-8c14632.0"
-  resolved "https://registry.yarnpkg.com/@agoric/store/-/store-0.9.3-dev-8c14632.0.tgz#72876454b8d38bcc55ad0b9d3989b9df28663d1f"
-  integrity sha512-U29be0hkGjsVu32WvD/MiV9MiUOc+k3yhDIQWN6d1vU8b4jeyce4lEDZMqMhkIm9f6PyJZdawF3x87/wftrgbg==
-  dependencies:
-    "@agoric/assert" "0.6.1-dev-8c14632.0+8c14632"
-    "@endo/exo" "^0.2.2"
-    "@endo/marshal" "^0.8.5"
-    "@endo/pass-style" "^0.1.3"
-    "@endo/patterns" "^0.2.2"
-
 "@agoric/store@^0.9.2":
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/@agoric/store/-/store-0.9.2.tgz#0973e57b8811a70923c141fccfb002bbad8fed4b"
@@ -353,24 +323,42 @@
     "@endo/nat" "4.1.27"
     better-sqlite3 "^8.2.0"
 
-"@agoric/swingset-liveslots@0.10.3-dev-8c14632.0", "@agoric/swingset-liveslots@^0.10.2", "@agoric/swingset-liveslots@^0.10.3-u13.0":
-  version "0.10.3-dev-8c14632.0"
-  resolved "https://registry.yarnpkg.com/@agoric/swingset-liveslots/-/swingset-liveslots-0.10.3-dev-8c14632.0.tgz#88334dc83f69ff14748e1ea96787b7dcf046009b"
-  integrity sha512-RthFdS0ekd9fKfSd2cDZeoUEORduPEVAUwx27lEad2t3HN8ERwmhZ4F3QCb0BsO+nFe2Svtu8haXdgAuibkwnA==
+"@agoric/swingset-liveslots@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@agoric/swingset-liveslots/-/swingset-liveslots-0.10.2.tgz#a8d18f32ff7a611b9945f4ff920b00b9e2801e08"
+  integrity sha512-jp05WNHEUH5K8MgiIoHhNrWu7ozKqStyIe0Ex6ejSInFFo/NhJLVL7QLyUgRjD74RbUSuvbR8v8PaQ/pslVI0Q==
   dependencies:
-    "@agoric/assert" "0.6.1-dev-8c14632.0+8c14632"
-    "@agoric/internal" "0.3.3-dev-8c14632.0+8c14632"
-    "@agoric/store" "0.9.3-dev-8c14632.0+8c14632"
-    "@agoric/vat-data" "0.5.3-dev-8c14632.0+8c14632"
+    "@agoric/assert" "^0.6.0"
+    "@agoric/internal" "^0.3.2"
+    "@agoric/store" "^0.9.2"
+    "@agoric/vat-data" "^0.5.2"
     "@endo/eventual-send" "^0.17.2"
     "@endo/exo" "^0.2.2"
-    "@endo/far" "^0.2.18"
     "@endo/init" "^0.5.56"
     "@endo/marshal" "^0.8.5"
     "@endo/nat" "^4.1.27"
     "@endo/pass-style" "^0.1.3"
     "@endo/patterns" "^0.2.2"
     "@endo/promise-kit" "^0.2.56"
+
+"@agoric/swingset-liveslots@^0.10.3-u13.0":
+  version "0.10.3-u13.0"
+  resolved "https://registry.yarnpkg.com/@agoric/swingset-liveslots/-/swingset-liveslots-0.10.3-u13.0.tgz#55f0e02e1cdc214068bd948fb421c980b38804bd"
+  integrity sha512-csSD/nPwfOC5tgqN+e4TKFidFI3pHRQjo3WRMgeduU5+NIHEMcIyXHFLyQvuLTRhfb/5b81T8imubr5hN6itzw==
+  dependencies:
+    "@agoric/assert" "^0.6.1-u11wf.0"
+    "@agoric/internal" "^0.4.0-u13.0"
+    "@agoric/store" "^0.9.3-u13.0"
+    "@agoric/vat-data" "^0.5.3-u13.0"
+    "@endo/eventual-send" "0.17.2"
+    "@endo/exo" "0.2.2"
+    "@endo/far" "0.2.18"
+    "@endo/init" "0.5.56"
+    "@endo/marshal" "0.8.5"
+    "@endo/nat" "4.1.27"
+    "@endo/pass-style" "0.1.3"
+    "@endo/patterns" "0.2.2"
+    "@endo/promise-kit" "0.2.56"
 
 "@agoric/swingset-vat@^0.32.2":
   version "0.32.2"
@@ -470,15 +458,6 @@
     "@agoric/assert" "^0.6.1-u11wf.0"
     "@agoric/store" "^0.9.3-u13.0"
     "@endo/nat" "4.1.27"
-
-"@agoric/vat-data@0.5.3-dev-8c14632.0+8c14632":
-  version "0.5.3-dev-8c14632.0"
-  resolved "https://registry.yarnpkg.com/@agoric/vat-data/-/vat-data-0.5.3-dev-8c14632.0.tgz#aee13fb73cef5783ad39d35dc1f2243c89719229"
-  integrity sha512-BDlBTnr6+zzXhotPkmy0GaufS2tN1+ZRn96u1RTITTvSyY7p5I8rUxufai3cctXyAdKv/ObbxCVwMWak5NvO1Q==
-  dependencies:
-    "@agoric/assert" "0.6.1-dev-8c14632.0+8c14632"
-    "@agoric/internal" "0.3.3-dev-8c14632.0+8c14632"
-    "@agoric/store" "0.9.3-dev-8c14632.0+8c14632"
 
 "@agoric/vat-data@^0.5.2":
   version "0.5.2"
@@ -608,15 +587,6 @@
     "@endo/nat" "^4.1.27"
     "@endo/patterns" "^0.2.2"
     "@endo/promise-kit" "^0.2.56"
-
-"@agoric/zone@0.2.3-dev-8c14632.0+8c14632":
-  version "0.2.3-dev-8c14632.0"
-  resolved "https://registry.yarnpkg.com/@agoric/zone/-/zone-0.2.3-dev-8c14632.0.tgz#76895453199ac16eec09c798c5d0e72ccde53db0"
-  integrity sha512-WC9S5vDia1qW6L4scrEMGqgFxcbJIqGbOnxWNxfrHrrfO76SplVwMPT8vkDBbBnPvD/iSlWUIppdzeOHY7E1gg==
-  dependencies:
-    "@agoric/store" "0.9.3-dev-8c14632.0+8c14632"
-    "@agoric/vat-data" "0.5.3-dev-8c14632.0+8c14632"
-    "@endo/far" "^0.2.18"
 
 "@agoric/zone@^0.2.2":
   version "0.2.2"
@@ -6406,6 +6376,11 @@ eslint-plugin-react@^7.27.1, eslint-plugin-react@^7.28.0, eslint-plugin-react@^7
     resolve "^2.0.0-next.4"
     semver "^6.3.0"
     string.prototype.matchall "^4.0.8"
+
+eslint-plugin-require-extensions@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-require-extensions/-/eslint-plugin-require-extensions-0.1.3.tgz#394aeab433f996797a6ceba0a3f75640d4846bc8"
+  integrity sha512-T3c1PZ9PIdI3hjV8LdunfYI8gj017UQjzAnCrxuo3wAjneDbTPHdE3oNWInOjMA+z/aBkUtlW5vC0YepYMZIug==
 
 eslint-plugin-testing-library@^5.0.1:
   version "5.11.0"


### PR DESCRIPTION
We need to use `.js` when importing local typescript files for ESM compatibility. https://github.com/Agoric/ui-kit/pull/76 fixes this, but this PR adds an eslint plugin (thanks [solana](https://github.com/solana-labs/eslint-plugin-require-extensions)) to protect against breaking it again.

I looked into other options, like libraries that transform extensionless imports to `.js` automatically, but seems like `.js` extensions are a common pattern in typescript libraries, and it seems less risky to not muck around with the build process.

Example output:

<img width="708" alt="Screenshot 2024-01-25 at 11 02 49 AM" src="https://github.com/Agoric/ui-kit/assets/8848650/59b54b1a-8060-4cbf-8683-66da39e8a16b">
