### PR TITLE
Deploy react components

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -87,5 +87,8 @@
     "*.{ts,tsx,js,jsx,json,css,md}": [
       "prettier -w"
     ]
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/react-components/src/lib/config/index.ts
+++ b/packages/react-components/src/lib/config/index.ts
@@ -45,5 +45,5 @@ export const makeAssetList = (chain_name: string) => {
     'Agoric missing from chain registry, cannot initiliaze test chains',
   );
 
-  return { ...agoricAssetList, chain_name };
+  return { ...agoricAssetList, chain_name } as AssetList;
 };


### PR DESCRIPTION
Failing deployment: https://github.com/Agoric/ui-kit/actions/runs/8092461024/job/22113217987

[Apparently](https://github.com/lerna/lerna/issues/1821) this means we need to set:
```
  "publishConfig": {
    "access": "public"
  }
 ```
...like the other packages. Setting `"private": false` is not enough.

Also fixed the non-fatal error:
```
Error: src/lib/config/index.ts(42,14): error TS2742: The inferred type of 'makeAssetList' cannot be named without a reference to 'chain-registry/node_modules/@chain-registry/types'. This is likely not portable. A type annotation is necessary.
```