### PR TITLE
fix: avoid marshaller error in watchWallet

### DIFF
--- a/packages/web-components/src/wallet-connection/watchWallet.js
+++ b/packages/web-components/src/wallet-connection/watchWallet.js
@@ -255,7 +255,7 @@ export const watchWallet = (
       const leader = makeLeader(rpc);
       const follower = makeFollower(`:published.wallet.${address}`, leader, {
         proof: 'none',
-        unserializer: Far('marshaller', chainStorageWatcher.marshaller),
+        unserializer: Far('marshaller', { ...chainStorageWatcher.marshaller }),
       });
 
       for await (const update of iterateEach(follower)) {


### PR DESCRIPTION
We changed it recently to wrap the marshaller in `Far`, which resulted in the following error and offer updates not being received:
```
wallet connection error Error: RPC error - Error: Remotable {"fromCapData":"[Function mn]","serialize":"[Function Ft]","toCapData":"[Function Ft]","unserialize":"[Function mn]"} is already frozen
```