### PR TITLE
feat: query smart wallet auto-provision fee

### DIFF
--- a/packages/react-components/src/lib/context/AgoricContext.ts
+++ b/packages/react-components/src/lib/context/AgoricContext.ts
@@ -43,6 +43,7 @@ export type AgoricState = {
   isSmartWalletProvisioned?: boolean;
   provisionSmartWallet?: AgoricWalletConnection['provisionSmartWallet'];
   makeOffer?: AgoricWalletConnection['makeOffer'];
+  smartWalletProvisionFee?: bigint;
 };
 
 export const AgoricContext = createContext<AgoricState>({});

--- a/packages/react-components/src/lib/context/AgoricProviderLite.tsx
+++ b/packages/react-components/src/lib/context/AgoricProviderLite.tsx
@@ -90,7 +90,6 @@ export const AgoricProviderLite = ({
       for await (const status of subscribeLatest(n)) {
         if (isCancelled) return;
         if (!status) continue;
-        console.log('wallet status', status);
         setIsSmartWalletProvisioned(status.provisioned);
         setSmartWalletProvisionFee(status.provisionFee);
       }

--- a/packages/react-components/src/lib/context/AgoricProviderLite.tsx
+++ b/packages/react-components/src/lib/context/AgoricProviderLite.tsx
@@ -63,6 +63,9 @@ export const AgoricProviderLite = ({
   const [isSmartWalletProvisioned, setIsSmartWalletProvisioned] = useState<
     boolean | undefined
   >(undefined);
+  const [smartWalletProvisionFee, setSmartWalletProvisionFee] = useState<
+    bigint | undefined
+  >(undefined);
 
   const { status, client } = useWalletClient();
   const chain = useChain(chainName);
@@ -87,7 +90,9 @@ export const AgoricProviderLite = ({
       for await (const status of subscribeLatest(n)) {
         if (isCancelled) return;
         if (!status) continue;
+        console.log('wallet status', status);
         setIsSmartWalletProvisioned(status.provisioned);
+        setSmartWalletProvisionFee(status.provisionFee);
       }
     };
 
@@ -213,6 +218,7 @@ export const AgoricProviderLite = ({
     isSmartWalletProvisioned,
     makeOffer: walletConnection?.makeOffer,
     provisionSmartWallet: walletConnection?.provisionSmartWallet,
+    smartWalletProvisionFee,
   };
 
   return (

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -17,6 +17,7 @@
     "@agoric/assert": "^0.6.0",
     "@agoric/cache": "^0.3.2",
     "@agoric/casting": "^0.4.3-u13.0",
+    "@agoric/cosmic-proto": "0.3.0",
     "@agoric/ertp": "^0.16.2",
     "@agoric/notifier": "^0.6.3-dev-8c14632.0",
     "@agoric/smart-wallet": "^0.5.3",
@@ -53,7 +54,7 @@
     "parserOptions": {
       "project": "./tsconfig.json"
     },
-    "env": { 
+    "env": {
       "browser": true
     }
   },

--- a/packages/web-components/src/wallet-connection/querySwingsetParams.js
+++ b/packages/web-components/src/wallet-connection/querySwingsetParams.js
@@ -1,0 +1,18 @@
+import { QueryClient, createProtobufRpcClient } from '@cosmjs/stargate';
+import { QueryClientImpl } from '@agoric/cosmic-proto/swingset/query.js';
+
+/** @typedef {import('@agoric/cosmic-proto/dist/agoric/swingset/query').QueryParamsResponse} QueryParamsResponse */
+/** @typedef {import('@cosmjs/tendermint-rpc').Tendermint34Client} Tendermint34Client */
+
+/**
+ * Query swingset params.
+ * @param {Tendermint34Client} tendermint
+ * @returns {Promise<QueryParamsResponse>}
+ */
+export const querySwingsetParams = async tendermint => {
+  const base = QueryClient.withExtensions(tendermint);
+  const rpc = createProtobufRpcClient(base);
+  const queryService = new QueryClientImpl(rpc);
+
+  return queryService.Params({});
+};

--- a/packages/web-components/src/wallet-connection/walletConnection.js
+++ b/packages/web-components/src/wallet-connection/walletConnection.js
@@ -24,7 +24,7 @@ export const makeAgoricWalletConnection = async (
   const { client, address } =
     clientConfig || (await connectKeplr(chainStorageWatcher.chainId, rpc));
 
-  const { submitSpendAction, provisionSmartWallet } = await makeAgoricSigner(
+  const { submitSpendAction, provisionSmartWallet } = makeAgoricSigner(
     client,
     address,
   );

--- a/packages/web-components/src/wallet-connection/watchWallet.js
+++ b/packages/web-components/src/wallet-connection/watchWallet.js
@@ -6,6 +6,7 @@ import { Tendermint34Client } from '@cosmjs/tendermint-rpc';
 import { AgoricChainStoragePathKind } from '@agoric/rpc';
 import { Far } from '@endo/marshal';
 import { queryBankBalances } from './queryBankBalances.js';
+import { querySwingsetParams } from './querySwingsetParams.js';
 
 /** @typedef {import("@agoric/rpc").ChainStorageWatcher} ChainStorageWatcher */
 /** @typedef {import('@agoric/smart-wallet/src/types.js').Petname} Petname */
@@ -31,6 +32,8 @@ import { queryBankBalances } from './queryBankBalances.js';
  *  }
  * ][]} VBankAssets
  */
+
+/** @typedef {import('@agoric/ertp/src/types.js').Amount<'nat'>['value']} NatValue */
 
 const POLL_INTERVAL_MS = 6000;
 const RETRY_INTERVAL_MS = 200;
@@ -79,24 +82,86 @@ export const watchWallet = (
   );
 
   const smartWalletStatusNotifierKit = makeNotifierKit(
-    /** @type { {provisioned: boolean} | null } */ (null),
+    /** @type { {provisioned: boolean, provisionFee?: NatValue} | null } */ (
+      null
+    ),
   );
 
   let lastPaths;
   let isWalletMissing = false;
+  /** @type {Promise<Tendermint34Client> | undefined} */
+  let tendermintClientP;
+
+  /** @returns {Promise<NatValue>} */
+  const fetchProvisionFee = async () => {
+    await null;
+    return new Promise((res, rej) => {
+      const query = async (attempts = 0) => {
+        await null;
+
+        try {
+          tendermintClientP ||= Tendermint34Client.connect(rpc);
+          const swingset = await querySwingsetParams(await tendermintClientP);
+          console.debug('got swingset params:', swingset);
+          const beansPerSmartWallet = swingset.params?.beansPerUnit.find(
+            ({ key }) => key === 'smartWalletProvision',
+          )?.beans;
+          const feeUnit = swingset.params?.beansPerUnit.find(
+            ({ key }) => key === 'feeUnit',
+          )?.beans;
+          const feeUnitPrice = swingset.params?.feeUnitPrice[0]?.amount;
+
+          if (!(feeUnitPrice && beansPerSmartWallet && feeUnit)) {
+            console.error('Provisioning fee missing from swingset params');
+            res(0n);
+            return;
+          }
+
+          const fee =
+            (BigInt(beansPerSmartWallet) / BigInt(feeUnit)) *
+            BigInt(feeUnitPrice);
+
+          res(fee);
+        } catch (e) {
+          console.error('Error querying smart wallet provision fee', address);
+          if (attempts >= MAX_ATTEMPTS_TO_WATCH_BANK) {
+            rej(e);
+          } else {
+            setTimeout(() => query(attempts + 1), RETRY_INTERVAL_MS);
+          }
+        }
+      };
+      query();
+    });
+  };
+
   chainStorageWatcher.watchLatest(
     [AgoricChainStoragePathKind.Data, `published.wallet.${address}.current`],
     value => {
       if (!value) {
         if (!isWalletMissing) {
-          smartWalletStatusNotifierKit.updater.updateState(
-            harden({ provisioned: false }),
-          );
           isWalletMissing = true;
+          fetchProvisionFee()
+            .then(provisionFee => {
+              if (isWalletMissing) {
+                smartWalletStatusNotifierKit.updater.updateState(
+                  harden({ provisioned: false, provisionFee }),
+                );
+              }
+            })
+            .catch(e => {
+              onError(new Error(`RPC error - ${e.toString?.()}`));
+              if (isWalletMissing) {
+                smartWalletStatusNotifierKit.updater.updateState(
+                  harden({ provisioned: false }),
+                );
+              }
+            });
         }
         return;
       }
 
+      isWalletMissing = false;
       smartWalletStatusNotifierKit.updater.updateState(
         harden({ provisioned: true }),
       );
@@ -140,14 +205,12 @@ export const watchWallet = (
         updatePurses(brandToPurse);
       };
 
-      /** @type {Tendermint34Client} */
-      let tendermintClient;
       const watchBank = async (attempts = 0) => {
         await null;
 
         try {
-          tendermintClient ||= await Tendermint34Client.connect(rpc);
-          bank = await queryBankBalances(address, tendermintClient);
+          tendermintClientP ||= Tendermint34Client.connect(rpc);
+          bank = await queryBankBalances(address, await tendermintClientP);
         } catch (e) {
           console.error('Error querying bank balances for address', address);
           if (attempts >= MAX_ATTEMPTS_TO_WATCH_BANK) {
@@ -173,6 +236,7 @@ export const watchWallet = (
 
       void watchVbankAssets();
       void watchBank();
+      void fetchProvisionFee();
     }
 
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,7 +92,7 @@
     "@endo/promise-kit" "0.2.56"
     node-fetch "^2.6.0"
 
-"@agoric/cosmic-proto@^0.3.0":
+"@agoric/cosmic-proto@0.3.0", "@agoric/cosmic-proto@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@agoric/cosmic-proto/-/cosmic-proto-0.3.0.tgz#c9d31d3946c91fbb1630f89d8ba63a662bcdacc5"
   integrity sha512-cIunby6gs53sGkHx3ALraREbfVQXvsIcObMjQQ0/tZt5HVqwoS7Y1Qj1Xl0ZZvqE8B1Zyk7QMDj829mbTII+9g==


### PR DESCRIPTION
refs https://github.com/Agoric/ui-kit/issues/78

This queries the smart wallet auto-provision fee in the wallet connection component, and exposes it in the react `useAgoric` hook as well.

Also fixed a bug where the purse notifier was updating every time the bank was polled, even if the balances didn't change. (cc @0xpatrickdev)

## Testing

Tested on this branch of dapp-offer-up: https://github.com/Agoric/dapp-offer-up/compare/test-network-dropdown

Steps:
- Build ui-kit with `yarn && yarn workspaces run prepack`
- Set up link with `cd packages/react-components && yarn link`
- Clone `dapp-offer-up` and checkout this branch: https://github.com/Agoric/dapp-offer-up/compare/test-network-dropdown
- Start the local chain with docker (the offer-up contract doesn't necessarily have to be deployed to test this functionality, just a local chain)
- Link the local version of this packages in dapp-offer-up: `cd ui && yarn link @agoric/react-components`
- Run the local UI: `cd ui && yarn && yarn dev`
- Try modifying the dapp to read the provision fee: `const { smartWalletProvisionFee } = useAgoric()`
- Observe after connecting to wallet that the provision fee is accessible

For an e2e example with the provision dialog, see https://github.com/Agoric/ui-kit/pull/99