### PR TITLE
feat(react-components): support IBC messages in signer

### DIFF
--- a/packages/react-components/src/lib/context/AgoricProviderLite.tsx
+++ b/packages/react-components/src/lib/context/AgoricProviderLite.tsx
@@ -22,6 +22,7 @@ import {
   defaultRegistryTypes,
   createBankAminoConverters,
   createAuthzAminoConverters,
+  createIbcAminoConverters,
 } from '@cosmjs/stargate';
 import { subscribeLatest } from '@agoric/notifier';
 import type { ChainName } from 'cosmos-kit';
@@ -178,6 +179,7 @@ export const AgoricProviderLite = ({
               ...agoricConverters,
               ...createBankAminoConverters(),
               ...createAuthzAminoConverters(),
+              ...createIbcAminoConverters(),
             }),
             registry: new Registry([
               ...defaultRegistryTypes,


### PR DESCRIPTION
refs https://github.com/Agoric/dapp-orchestration-basics/issues/43

This way we'll be able to use `walletConnection.signingClient` to send an IBC transfer instead of [creating our own signer](https://github.com/Agoric/dapp-orchestration-basics/blob/f7a4ed386582f7f6b00d7f997ae8d79b1c05c3c2/ui/src/components/Orchestration/Orchestration.tsx#L160-L166) which doesn't use the wallet extension and rpc endpoints configured by cosmos-kit.

Tested locally with dapp-orchestration-basics https://github.com/Agoric/dapp-orchestration-basics/commit/ca700b2971181f971a329ee73bb56a8ba7a7b210