### PR TITLE
react-components fixes

### DIFF
--- a/packages/react-components/src/lib/context/AgoricContext.ts
+++ b/packages/react-components/src/lib/context/AgoricContext.ts
@@ -1,12 +1,7 @@
 import { createContext } from 'react';
 import { makeAgoricWalletConnection } from '@agoric/web-components';
 import type { ChainStorageWatcher } from '@agoric/rpc';
-import type {
-  Brand,
-  Amount,
-  AssetKind,
-  AmountValue,
-} from '@agoric/ertp/src/types';
+import type { Brand, Amount, AssetKind } from '@agoric/ertp/src/types';
 
 export type PurseJSONState<T extends AssetKind> = {
   brand: Brand;

--- a/packages/react-components/src/lib/context/AgoricProvider.tsx
+++ b/packages/react-components/src/lib/context/AgoricProvider.tsx
@@ -1,4 +1,4 @@
-import { ChainProvider } from '@cosmos-kit/react';
+import { ChainProvider, type ThemeCustomizationProps } from '@cosmos-kit/react';
 import { AgoricProviderLite } from './AgoricProviderLite';
 import { chains, assets } from 'chain-registry';
 import { makeAssetList, makeChainInfo } from '../config';
@@ -17,6 +17,7 @@ export type AgoricProviderProps = PropsWithChildren<{
   walletConnectOptions?: WalletConnectOptions;
   onConnectionError?: (e: unknown) => void;
   provisionNoticeContent?: ProvisionNoticeProps['mainContent'];
+  modalTheme?: ThemeCustomizationProps;
 }>;
 
 export const AgoricProvider = (props: AgoricProviderProps) => {
@@ -37,6 +38,7 @@ const AgoricProviderInner = ({
   children,
   onConnectionError,
   provisionNoticeContent,
+  modalTheme,
 }: AgoricProviderProps) => {
   const { networkConfig } = useContext(NetworkContext);
   assert(networkConfig, 'Network config missing from context');
@@ -57,6 +59,7 @@ const AgoricProviderInner = ({
         endpoints: { [chainName]: apis },
         isLazy: true,
       }}
+      modalTheme={modalTheme}
     >
       <AgoricProviderLite
         chainName={chainName}


### PR DESCRIPTION
closes https://github.com/Agoric/ui-kit/issues/119
closes https://github.com/Agoric/ui-kit/issues/118

## Description

For https://github.com/Agoric/ui-kit/issues/118, this adds the `modalTheme` prop to the `AgoricProvider`, which seems to successfully allow style overrides when tested with https://github.com/Agoric/ui-kit/tree/main/packages/example.

For https://github.com/Agoric/ui-kit/issues/119, it fixes the logic to call `onStatusUpdate` when the dialog is dismissed without proceeding.

## Testing

Tested in https://github.com/Agoric/ui-kit/tree/main/packages/example manually.

## Documentation Considerations

The `modalTheme` prop supports customization via overrides, as well as creating a custom theme, as documented in https://docs.cosmology.zone/cosmos-kit/migration-to-v2#customizing-the-default-modal. Unfortunately, the customization doesn't seem to work too well. I wasn't able to get a custom theme working, even when testing in isolation, and the overrides are very limited. For example, you can override the button background color, but can't specify it according to button type, so the "Proceed" and "Go Back" buttons in the provision dialog will end up the same color. Because of this, I wouldn't recommend devs do that unless they implement a custom dialog/provision flow altogether. The option is still available at least. I don't think it looks too bad to use the default styling because it's in a modal, so it's less jarring if it doesn't match the rest of the app.